### PR TITLE
package/gstreamer1/gst1-imx: Fix compile error

### DIFF
--- a/src/ipu/blitter.c
+++ b/src/ipu/blitter.c
@@ -25,6 +25,7 @@
 #include "allocator.h"
 #include "device.h"
 #include "../common/phys_mem_meta.h"
+#include <linux/types.h>
 
 
 GST_DEBUG_CATEGORY_STATIC(imx_ipu_blitter_debug);
@@ -33,6 +34,8 @@ GST_DEBUG_CATEGORY_STATIC(imx_ipu_blitter_debug);
 
 G_DEFINE_TYPE(GstImxIpuBlitter, gst_imx_ipu_blitter, GST_TYPE_IMX_BLITTER)
 
+typedef __u8 u8;
+typedef __u32 u32;
 
 /* Private structure storing IPU specific data */
 struct _GstImxIpuBlitterPrivate


### PR DESCRIPTION
Added patch for Buildroot 2022.02.1. This patch is for CL713 product. 